### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for C…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://github.com/alrevuelta/eth-pools-metrics/actions/workflows/release.yml/badge.svg)](https://github.com/alrevuelta/eth-pools-metrics/actions/workflows/release.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/alrevuelta/eth-pools-metrics)](https://goreportcard.com/report/github.com/alrevuelta/eth-pools-metrics)
 [![Tests](https://github.com/alrevuelta/eth-pools-metrics/actions/workflows/tests.yml/badge.svg)](https://github.com/alrevuelta/eth-pools-metrics/actions/workflows/tests.yml)
+[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/alrevuelta/eth-metrics/badge)](https://www.gitpoap.io/gh/alrevuelta/eth-metrics)
 
 ## Introduction
 


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie