### PR TITLE
Add flag + read more recent epoch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Eth2Address           string
 	EpochDebug            string
 	Verbosity             string
+	StateTimeout          int
 }
 
 // custom implementation to allow providing the same flag multiple times
@@ -55,6 +56,7 @@ func NewCliConfig() (*Config, error) {
 	var postgres = flag.String("postgres", "", "Postgres db endpoit: postgresql://user:password@netloc:port/dbname (optional)")
 	var eth1Address = flag.String("eth1address", "", "Ethereum 1 http endpoint. To be used by rocket pool")
 	var eth2Address = flag.String("eth2address", "", "Ethereum 2 http endpoint")
+	var stateTimeout = flag.Int("state-timeout", 60, "Timeout in seconds for fetching the beacon state")
 	var epochDebug = flag.String("epoch-debug", "", "Calculates the stats for a given epoch and exits, useful for debugging")
 	var verbosity = flag.String("verbosity", "info", "Logging verbosity (trace, debug, info=default, warn, error, fatal, panic)")
 	flag.Parse()
@@ -92,6 +94,7 @@ func NewCliConfig() (*Config, error) {
 		Eth2Address:           *eth2Address,
 		EpochDebug:            *epochDebug,
 		Verbosity:             *verbosity,
+		StateTimeout:          *stateTimeout,
 	}
 	logConfig(conf)
 	return conf, nil

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,6 +27,7 @@ import (
 )
 
 type Metrics struct {
+	// TODO: Remove unneeded stuff
 	beaconChainClient ethpb.BeaconChainClient
 	validatorClient   ethpb.BeaconNodeValidatorClient
 	nodeClient        ethpb.NodeClient
@@ -40,7 +41,7 @@ type Metrics struct {
 	fromAddrList   []string
 	eth1Address    string
 	eth2Address    string
-	theGraph       *thegraph.Thegraph
+	theGraph       *thegraph.Thegraph // TODO: Remove
 	postgresql     *postgresql.Postgresql
 
 	httpClient *http.Service
@@ -55,6 +56,7 @@ type Metrics struct {
 
 	PoolNames  []string
 	epochDebug string
+	config     *config.Config // TODO: Remove repeated parameters
 }
 
 func NewMetrics(
@@ -119,6 +121,7 @@ func NewMetrics(
 		PoolNames:   config.PoolNames,
 		httpClient:  httpClient,
 		epochDebug:  config.EpochDebug,
+		config:      config,
 	}, nil
 }
 
@@ -129,6 +132,7 @@ func (a *Metrics) Run() {
 		a.postgresql,
 		a.fromAddrList,
 		a.PoolNames,
+		a.config.StateTimeout,
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -165,15 +169,17 @@ func (a *Metrics) Loop() {
 		headSlot, err := a.httpClient.NodeSyncing(context.Background())
 		if err != nil {
 			log.Error("Could not get node sync status:", err)
+			time.Sleep(5 * time.Second)
 			continue
 		}
 
 		if headSlot.IsSyncing {
 			log.Error("Node is not in sync")
+			time.Sleep(5 * time.Second)
 			continue
 		}
 
-		currentEpoch := uint64(headSlot.HeadSlot)/uint64(32) - 3
+		currentEpoch := uint64(headSlot.HeadSlot)/uint64(32) - 2
 
 		// If a debug epoch is set, overwrite the slot. Will compute just metrics for that epoch
 		if a.epochDebug != "" {


### PR DESCRIPTION
* Add `state-timeout` that allows to set a timeout in second when requesting the beacon state. This comes in handy when using a beacon node from a different machine, in which case it may take up to 1/2 minutes to stream the whole beacon state. Note that it can be left empty if the beacon node is running within the same machine.
* Fetches the beacon state `2` epochs from head instead of `3`.