### PR TITLE
Add Capella support to beacon state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alrevuelta/eth-pools-metrics
 go 1.17
 
 require (
-	github.com/attestantio/go-eth2-client v0.13.4
+	github.com/attestantio/go-eth2-client v0.14.5
 	github.com/ethereum/go-ethereum v1.10.14
 	github.com/jackc/pgx/v4 v4.14.1
 	github.com/pkg/errors v0.9.1
@@ -40,7 +40,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.9.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
-	github.com/klauspost/cpuid/v2 v2.1.1 // indirect
+	github.com/klauspost/cpuid/v2 v2.1.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
@@ -62,9 +62,9 @@ require (
 	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
+	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/attestantio/go-eth2-client v0.13.4 h1:MT3+28KDkmCa9Zb3lLQz0A87q7PGsmXS0VRI5LzkkkM=
 github.com/attestantio/go-eth2-client v0.13.4/go.mod h1:bcg5gfjVcm+MtcaZfzv/uSWNHU4i8hGamVG+9JCZnC0=
+github.com/attestantio/go-eth2-client v0.14.5 h1:pKOTcbv9KOiVixVKM5Cr8nJrjD1VOIWmrlNFO0YtF64=
+github.com/attestantio/go-eth2-client v0.14.5/go.mod h1:5kLLzdlyPGboWr8tAwnG/4Kpi43BHd/HWp++WmmP6Ws=
 github.com/aws/aws-sdk-go-v2 v1.2.0/go.mod h1:zEQs02YRBw1DjK0PoJv3ygDYOFTre1ejlJWl8FwAuQo=
 github.com/aws/aws-sdk-go-v2/config v1.1.1/go.mod h1:0XsVy9lBI/BCXm+2Tuvt39YmdHwS5unDQmxZOYe8F5Y=
 github.com/aws/aws-sdk-go-v2/credentials v1.1.1/go.mod h1:mM2iIjwl7LULWtS6JCACyInboHirisUUdkBPoTHMOUo=
@@ -243,6 +245,7 @@ github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5Nq
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/goccy/go-yaml v1.9.2/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/goccy/go-yaml v1.9.5 h1:Eh/+3uk9kLxG4koCX6lRMAPS1OaMSAi+FJcya0INdB0=
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -466,6 +469,8 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/klauspost/cpuid/v2 v2.1.1 h1:t0wUqjowdm8ezddV5k0tLWVklVuvLJpoHeb4WBdydm0=
 github.com/klauspost/cpuid/v2 v2.1.1/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/klauspost/cpuid/v2 v2.1.2 h1:XhdX4fqAJUA0yj+kUwMavO0hHrSPAecYdYf1ZmxHvak=
+github.com/klauspost/cpuid/v2 v2.1.2/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -968,6 +973,8 @@ golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
@@ -1051,6 +1058,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.6.0/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=

--- a/metrics/beaconstate.go
+++ b/metrics/beaconstate.go
@@ -8,18 +8,18 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
-
-	//"github.com/alrevuelta/eth-pools-metrics/prometheus"
-
-	"github.com/alrevuelta/eth-pools-metrics/postgresql"
-	"github.com/alrevuelta/eth-pools-metrics/prometheus"
-	"github.com/alrevuelta/eth-pools-metrics/schemas"
-	"github.com/alrevuelta/eth-pools-metrics/config"
 	"github.com/attestantio/go-eth2-client/http"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+
+	//"github.com/alrevuelta/eth-pools-metrics/prometheus"
+
+	"github.com/alrevuelta/eth-pools-metrics/config"
+	"github.com/alrevuelta/eth-pools-metrics/postgresql"
+	"github.com/alrevuelta/eth-pools-metrics/prometheus"
+	"github.com/alrevuelta/eth-pools-metrics/schemas"
 	"github.com/rs/zerolog"
 
 	log "github.com/sirupsen/logrus"
@@ -574,6 +574,8 @@ func GetValidators(beaconState *spec.VersionedBeaconState) []*phase0.Validator {
 		validators = beaconState.Altair.Validators
 	} else if beaconState.Bellatrix != nil {
 		validators = beaconState.Bellatrix.Validators
+	} else if beaconState.Capella != nil {
+		validators = beaconState.Capella.Validators
 	} else {
 		log.Fatal("Beacon state was empty")
 	}
@@ -581,13 +583,20 @@ func GetValidators(beaconState *spec.VersionedBeaconState) []*phase0.Validator {
 }
 
 func GetBalances(beaconState *spec.VersionedBeaconState) []uint64 {
-	var balances []uint64
+	var tmpBalances []phase0.Gwei
 	if beaconState.Altair != nil {
-		balances = beaconState.Altair.Balances
+		tmpBalances = beaconState.Altair.Balances
 	} else if beaconState.Bellatrix != nil {
-		balances = beaconState.Bellatrix.Balances
+		tmpBalances = beaconState.Bellatrix.Balances
+	} else if beaconState.Capella != nil {
+		tmpBalances = beaconState.Capella.Balances
 	} else {
 		log.Fatal("Beacon state was empty")
+	}
+
+	balances := make([]uint64, len(tmpBalances))
+	for i := range tmpBalances {
+		balances[i] = uint64(tmpBalances[i])
 	}
 	return balances
 }
@@ -598,6 +607,8 @@ func GetPreviousEpochParticipation(beaconState *spec.VersionedBeaconState) []alt
 		previousEpochParticipation = beaconState.Altair.PreviousEpochParticipation
 	} else if beaconState.Bellatrix != nil {
 		previousEpochParticipation = beaconState.Bellatrix.PreviousEpochParticipation
+	} else if beaconState.Capella != nil {
+		previousEpochParticipation = beaconState.Capella.PreviousEpochParticipation
 	} else {
 		log.Fatal("Beacon state was empty")
 	}
@@ -607,9 +618,11 @@ func GetPreviousEpochParticipation(beaconState *spec.VersionedBeaconState) []alt
 func GetSlot(beaconState *spec.VersionedBeaconState) uint64 {
 	var slot uint64
 	if beaconState.Altair != nil {
-		slot = beaconState.Altair.Slot
+		slot = uint64(beaconState.Altair.Slot)
 	} else if beaconState.Bellatrix != nil {
-		slot = beaconState.Bellatrix.Slot
+		slot = uint64(beaconState.Bellatrix.Slot)
+	} else if beaconState.Capella != nil {
+		slot = uint64(beaconState.Capella.Slot)
 	} else {
 		log.Fatal("Beacon state was empty")
 	}
@@ -622,6 +635,8 @@ func GetCurrentSyncCommittee(beaconState *spec.VersionedBeaconState) []phase0.BL
 		pubKeys = beaconState.Altair.CurrentSyncCommittee.Pubkeys
 	} else if beaconState.Bellatrix != nil {
 		pubKeys = beaconState.Bellatrix.CurrentSyncCommittee.Pubkeys
+	} else if beaconState.Capella != nil {
+		pubKeys = beaconState.Capella.CurrentSyncCommittee.Pubkeys
 	} else {
 		log.Fatal("Beacon state was empty")
 	}


### PR DESCRIPTION
# Motivation
Capella Fork has recently happened in Goerli as it is planned to happen in mainnet, Therefore, with the below changes we aim to add support to handle Capella / Shangai fork beacon states. 

# Changes
- Add Capella Beacon State fields retrieval.
- Updated go-eth2-client version to use Capella methods
- Parse balances to uint64 manually

The changes have been tested on go 1.17.2